### PR TITLE
Fix example usage code

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ grunt.loadNpmTasks('grunt-bower-requirejs');
 
 ```js
 grunt.initConfig({
-  bower: {
+  bowerRequirejs: {
     target: {
       rjsConfig: 'app/config.js'
     }


### PR DESCRIPTION
I think `bower:` should be `bowerRequirejs:` in the example use case